### PR TITLE
Bug in displayContentController:

### DIFF
--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -176,16 +176,16 @@ const int INTERSTITIAL_STEPS = 99;
 
 - (void)displayContentController:(UIViewController *)content;
 {
-    [self addChildViewController:content];
-    content.view.frame = self.view.bounds;
-    [self.view addSubview:content.view];
-    [content didMoveToParentViewController:self];
-
     if (self.topController) {
         [self.topController willMoveToParentViewController:nil];
         [self.topController.view removeFromSuperview];
         [self.topController removeFromParentViewController];
     }
+    
+    [self addChildViewController:content];
+    content.view.frame = self.view.bounds;
+    [self.view addSubview:content.view];
+    [content didMoveToParentViewController:self];
     
     self.topController = content;
     


### PR DESCRIPTION
If the controller passed to displayContentController is the same controller as the current topController, then it will first be added to the hierarchy, and after passing the conditional statement, it will be removed immediately. This small pull request flips the order, so that the top is removed first, and then the new controller is added.
