### PR TITLE
added closedSideMenu and willOpenSideMenu notifications

### DIFF
--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -146,6 +146,8 @@ const int INTERSTITIAL_STEPS = 99;
     
     UITapGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tapGestureRecognized:)];
     [_screenshotView addGestureRecognizer:tapGestureRecognizer];
+
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"didOpenSideMenu" object:nil];
 }
 
 - (void)minimizeFromRect:(CGRect)rect


### PR DESCRIPTION
so external classes can hook into menu animations. motivation: mapbox views need to be turned into images in a special way in order to be turned into a thumbnail. useful for other stuff too, though.
