### PR TITLE
Fix menu closing on inappropriate rotation events

### DIFF
--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -603,9 +603,15 @@ NSString * const RESideMenuDidClose = @"RESideMenuDidClose";
 
 - (void)deviceOrientationDidChange
 {
-    if (_isShowing) {
-        [self performSelector:@selector(hide) withObject:nil afterDelay:0.1];
-        [[self class] performSelector:@selector(attemptRotationToDeviceOrientation) withObject:nil afterDelay:0.5];
+    UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
+    if (orientation == UIDeviceOrientationPortrait ||
+        orientation == UIDeviceOrientationPortraitUpsideDown ||
+        orientation == UIDeviceOrientationLandscapeLeft ||
+        orientation == UIDeviceOrientationLandscapeRight) {
+        if ((UIInterfaceOrientation)orientation != self.interfaceOrientation && _isShowing) {
+            [self performSelector:@selector(hide) withObject:nil afterDelay:0.1];
+            [[self class] performSelector:@selector(attemptRotationToDeviceOrientation) withObject:nil afterDelay:0.5];
+        }
     }
 }
 


### PR DESCRIPTION
This commit will prevent the menu from closing when orientation change is UIDeviceOrientationFaceDown or UIDeviceOrientationFaceUp. 

Seeing as we have to register for device orientation changes rather than interface ones (because they have to be intercepted) the callback was being fired unnecessarily when no rotation had taken place, for instance when a user picked up their device.
