### PR TITLE
Set clipsToBounds = YES on the side menu view.

### DIFF
--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -142,6 +142,12 @@ NSString * const RESideMenuDidClose = @"RESideMenuDidClose";
     }];
 }
 
+-(void)viewDidLoad
+{
+    [super viewDidLoad];
+    self.view.clipsToBounds = YES;
+}
+
 #pragma mark -
 #pragma markPublic API
 


### PR DESCRIPTION
This prevents the screenshot view appearing outside of the bounds of the controller's view - for example, when used as the master controller in a UISplitViewController
