### PR TITLE
added support for pan gesture forwarding

### DIFF
--- a/RESideMenu/RESideMenu.h
+++ b/RESideMenu/RESideMenu.h
@@ -26,6 +26,10 @@
 #import <UIKit/UIKit.h>
 #import "UIViewController+RESideMenu.h"
 
+@protocol REGestureRecipient <NSObject>
+- (void)panGestureRecognized:(UIPanGestureRecognizer *)recognizer;
+@end
+
 @interface RESideMenu : UIViewController
 
 @property (assign, readwrite, nonatomic) NSTimeInterval animationDuration;

--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -276,8 +276,12 @@
 
 - (void)panGestureRecognized:(UIPanGestureRecognizer *)recognizer
 {
-    if (!self.panGestureEnabled)
+    if (!self.panGestureEnabled) {
+        if ([self.contentViewController conformsToProtocol:@protocol(REGestureRecipient)]) {
+            [((id <REGestureRecipient>) self.contentViewController) panGestureRecognized:recognizer];
+        }
         return;
+    }
     
     CGPoint point = [recognizer translationInView:self.view];
     


### PR DESCRIPTION
If the contentViewController is not a standalone controller (for example, it's a navigation controller), you might want to provide access to the menu on some child controllers but not others. All pan/swipe gestures, however, are currently handled by the menu controller. 

This change provides a protocol that interested content controllers can implement; If the pan gesture is disabled on the menu controller itself at the time of the gesture, this protocol allows the menu's contentViewController to handle the gesture differently.
