### PR TITLE
Renamed category to RESideMenu in implementation for consistency

### DIFF
--- a/RESideMenu/UIViewController+RESideMenu.m
+++ b/RESideMenu/UIViewController+RESideMenu.m
@@ -26,7 +26,7 @@
 #import "UIViewController+RESideMenu.h"
 #import "RESideMenu.h"
 
-@implementation UIViewController (REFrostedViewController)
+@implementation UIViewController (RESideMenu)
 
 - (void)re_displayController:(UIViewController *)controller frame:(CGRect)frame
 {


### PR DESCRIPTION
I'm unsure why there is a reference to the REFrostedViewController category in this code.  Changing it to RESideMenu as defined in the header didn't seem to break anything.

Was this a typo or deliberate?
