### PR TITLE
Resolve conflict between side-menu pan gesture and ios-7 swipe-back

### DIFF
--- a/Examples/Storyboards/RESideMenuStoryboardsExample/Base.lproj/Main.storyboard
+++ b/Examples/Storyboards/RESideMenuStoryboardsExample/Base.lproj/Main.storyboard
@@ -85,6 +85,18 @@
                     <view key="view" contentMode="scaleToFill" id="zr4-Ue-MTR">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="L0v-7c-gKp">
+                                <rect key="frame" x="97" y="116" width="126" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Push Controller">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="pushController:" destination="yGP-ij-jME" eventType="touchUpInside" id="KHm-s5-FrO"/>
+                                </connections>
+                            </button>
+                        </subviews>
                         <color key="backgroundColor" red="1" green="0.7902456898061645" blue="0.39722655648262306" alpha="1" colorSpace="calibratedRGB"/>
                     </view>
                     <navigationItem key="navigationItem" title="Second Controller" id="8VR-6H-mGr">

--- a/Examples/Storyboards/RESideMenuStoryboardsExample/DEMOSecondViewController.h
+++ b/Examples/Storyboards/RESideMenuStoryboardsExample/DEMOSecondViewController.h
@@ -12,5 +12,6 @@
 @interface DEMOSecondViewController : UIViewController
 
 - (IBAction)showMenu;
+- (IBAction)pushController:(id)sender;
 
 @end

--- a/Examples/Storyboards/RESideMenuStoryboardsExample/DEMOSecondViewController.m
+++ b/Examples/Storyboards/RESideMenuStoryboardsExample/DEMOSecondViewController.m
@@ -19,4 +19,12 @@
     [self.sideMenuViewController presentMenuViewController];
 }
 
+- (IBAction)pushController:(id)sender
+{
+    UIViewController *vc = [[UIViewController alloc] init];
+    vc.title = @"Pushed Controller";
+    vc.view.backgroundColor = [UIColor whiteColor];
+    [self.navigationController pushViewController:vc animated:YES];
+}
+
 @end

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ You can customize the following properties of `RESideMenu`:
 @property (assign, readwrite, nonatomic) NSTimeInterval animationDuration;
 @property (strong, readwrite, nonatomic) UIImage *backgroundImage;
 @property (assign, readwrite, nonatomic) BOOL panGestureEnabled;
+@property (assign, readwrite, nonatomic) BOOL disablePanGestureWhenSwipeBackEnabled;;
 @property (assign, readwrite, nonatomic) BOOL scaleContentView;
 @property (assign, readwrite, nonatomic) BOOL scaleBackgroundImageView;
 @property (assign, readwrite, nonatomic) CGFloat contentViewScaleValue;

--- a/RESideMenu/RESideMenu.h
+++ b/RESideMenu/RESideMenu.h
@@ -34,6 +34,7 @@
 @property (strong, readwrite, nonatomic) UIImage *backgroundImage;
 @property (assign, readwrite, nonatomic) BOOL panGestureEnabled;
 @property (assign, readwrite, nonatomic) BOOL panFromEdge;
+@property (assign, readwrite, nonatomic) BOOL disablePanGestureWhenSwipeBackEnabled;
 @property (assign, readwrite, nonatomic) BOOL scaleContentView;
 @property (assign, readwrite, nonatomic) BOOL scaleBackgroundImageView;
 @property (assign, readwrite, nonatomic) CGFloat contentViewScaleValue;

--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -60,6 +60,7 @@
 {
     _animationDuration = 0.35f;
     _panGestureEnabled = YES;
+    _disablePanGestureWhenSwipeBackEnabled = YES;
   
     _scaleContentView      = YES;
     _contentViewScaleValue = 0.7f;
@@ -293,6 +294,13 @@
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
 {
+    if (self.disablePanGestureWhenSwipeBackEnabled && [self.contentViewController isKindOfClass:[UINavigationController class]]) {
+        UINavigationController *nc = (UINavigationController *)self.contentViewController;
+        if (nc.viewControllers.count > 1 && nc.interactivePopGestureRecognizer.enabled) {
+            return NO;
+        }
+    }
+  
     if (self.panFromEdge && [gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]] && !self.visible) {
         CGPoint point = [touch locationInView:gestureRecognizer.view];
         if (point.x < 30) {


### PR DESCRIPTION
Resolve conflict between side-menu pan gesture and ios-7 swipe-back gesture. 
Added a new configuration "disablePanGestureWhenSwipeBackEnabled".

The problem: In a view with system "Back" button, the user can go back
by simply swiping from the edge. The SideMenu's pan gesture overrides it.

Fix:
Now pan gesture is automatically disabled if the following satisfies
1. disablePanGestureWhenSwipeBackEnabled == YES, and
2. The content view controller is a UINavigationViewController, and
3. There are more than 1 view controllers in the navigation controller's
stack, and
4. interactivePopGestureRecognizer.enabled == YES
Then the user can trigger the swiping back gesture correctly.

Also added sample code in the storyboard sample. 

![ios simulator screen shot dec 10 2013 5 32 50 pm](https://f.cloud.github.com/assets/746943/1720508/2ee348a0-6204-11e3-952a-790a892cdb88.png)

![ios simulator screen shot dec 10 2013 5 33 15 pm](https://f.cloud.github.com/assets/746943/1720510/3813e15a-6204-11e3-966b-df980c4a9c30.png)
