### PR TITLE
Create bouncesHorizontally property

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ You can customize the following properties of `RESideMenu`:
 @property (strong, readwrite, nonatomic) id parallaxContentMinimumRelativeValue;
 @property (strong, readwrite, nonatomic) id parallaxContentMaximumRelativeValue;
 @property (assign, readwrite, nonatomic) BOOL parallaxEnabled;
+@property (assign, readwrite, nonatomic) BOOL bouncesHorizontally;
 ```
 
 You can implement `RESideMenuDelegate` protocol to receive the following messages:

--- a/RESideMenu/RESideMenu.h
+++ b/RESideMenu/RESideMenu.h
@@ -45,6 +45,7 @@
 @property (strong, readwrite, nonatomic) id parallaxContentMinimumRelativeValue;
 @property (strong, readwrite, nonatomic) id parallaxContentMaximumRelativeValue;
 @property (assign, readwrite, nonatomic) BOOL parallaxEnabled;
+@property (assign, readwrite, nonatomic) BOOL bouncesHorizontally;
 
 @property (strong, readwrite, nonatomic) UIViewController *contentViewController;
 @property (strong, readwrite, nonatomic) UIViewController *menuViewController;

--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -73,6 +73,8 @@
     
     _parallaxContentMinimumRelativeValue = @(-25);
     _parallaxContentMaximumRelativeValue = @(25);
+
+    _bouncesHorizontally = YES;
 }
 
 - (id)initWithContentViewController:(UIViewController *)contentViewController menuViewController:(UIViewController *)menuViewController
@@ -349,6 +351,12 @@
         CGFloat contentViewScale = self.scaleContentView ? 1 - ((1 - self.contentViewScaleValue) * delta) : 1;
         CGFloat backgroundViewScale = 1.7f - (0.7f * delta);
         CGFloat menuViewScale = 1.5f - (0.5f * delta);
+
+        if (!_bouncesHorizontally) {
+            contentViewScale = MAX(contentViewScale, self.contentViewScaleValue);
+            backgroundViewScale = MAX(backgroundViewScale, 1.0);
+            menuViewScale = MAX(menuViewScale, 1.0);
+        }
         
         self.menuViewController.view.alpha = delta;
         if (self.scaleBackgroundImageView) {
@@ -368,6 +376,10 @@
             }
             self.contentViewController.view.frame = self.view.bounds;
         } else {
+            if (!_bouncesHorizontally && self.visible) {
+                point.x = MIN(0.0, point.x);
+                [recognizer setTranslation:point inView:self.view];
+            }
             self.contentViewController.view.transform = CGAffineTransformMakeScale(contentViewScale, contentViewScale);
             self.contentViewController.view.transform = CGAffineTransformTranslate(self.contentViewController.view.transform, point.x, 0);
         }


### PR DESCRIPTION
This adds the ability for the developer to customize the RESideMenu further with the addition of the **bouncesHorizontally** property. It works similarly to UIScrollView's **alwaysBounceHorizontal** property. It fixes a problem in which if the **menuViewController.view** is not 100% transparent, it would look weird. To illustrate it, let us take a look at a few screenshots.
1. In the image below, the menu is visible, but no dragging action is happening.
   ![menu_visible](https://f.cloud.github.com/assets/650942/1770940/a11eca9e-67a3-11e3-9081-bba7ed252b98.png)
2. If we drag it further to the right, the bounce effect causes a weird effect, which may not be what the developer wanted.
   ![menu_bounce](https://f.cloud.github.com/assets/650942/1770955/28eedc70-67a4-11e3-86eb-955a4d430369.png)

In conclusion, this property helps alleviate that problem by not allowing the scaling and translation animations of the **menuViewController** and **contentViewController** go beyond the maximum threshold.
