### PR TITLE
fixed issue with motion effect being applied when closed

### DIFF
--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -420,7 +420,9 @@
     contentViewController.view.transform = transform;
     contentViewController.view.frame = frame;
     
-    [self addContentViewControllerMotionEffects];
+    if(self.visible) {
+        [self addContentViewControllerMotionEffects];
+    }
 }
 
 - (void)setContentViewController:(UIViewController *)contentViewController animated:(BOOL)animated


### PR DESCRIPTION
I noticed when setContentViewController:animated: was called with animation it would add motion controls to my content view controller, which is not the desired behavior. This would present a problem if closing the menu right after adding a new content view controller. I add a check to make sure the menu was not closed before adding the motion controls. Also thanks for sharing this, very nice library.
