### PR TITLE
Add showMenu IBAction to UIViewController category

### DIFF
--- a/RESideMenu/UIViewController+RESideMenu.h
+++ b/RESideMenu/UIViewController+RESideMenu.h
@@ -34,4 +34,8 @@
 - (void)re_displayController:(UIViewController *)controller frame:(CGRect)frame;
 - (void)re_hideController:(UIViewController *)controller;
 
+#pragma mark - Action methods
+
+- (IBAction)showMenu;
+
 @end

--- a/RESideMenu/UIViewController+RESideMenu.m
+++ b/RESideMenu/UIViewController+RESideMenu.m
@@ -58,4 +58,11 @@
     return nil;
 }
 
+#pragma mark - Action methods
+
+- (IBAction)showMenu
+{
+    [self.sideMenuViewController presentMenuViewController];
+}
+
 @end


### PR DESCRIPTION
Developers won't have to include this method in all the needed view controllers: less code duplication.
