### PR TITLE
Added an option to enable/disable menuViewController scaling while panning

### DIFF
--- a/RESideMenu/RESideMenu.h
+++ b/RESideMenu/RESideMenu.h
@@ -56,6 +56,7 @@
 @property (assign, readwrite, nonatomic) CGFloat parallaxContentMinimumRelativeValue;
 @property (assign, readwrite, nonatomic) CGFloat parallaxContentMaximumRelativeValue;
 @property (assign, readwrite, nonatomic) CGAffineTransform menuViewControllerTransformation;
+@property (assign, readwrite, nonatomic) BOOL scaleMenuView;
 @property (assign, readwrite, nonatomic) BOOL parallaxEnabled;
 @property (assign, readwrite, nonatomic) BOOL bouncesHorizontally;
 @property (assign, readwrite, nonatomic) UIStatusBarStyle menuPreferredStatusBarStyle;

--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -74,6 +74,7 @@
     
     _scaleContentView      = YES;
     _scaleBackgroundImageView = YES;
+    _scaleMenuView = YES;
     
     _parallaxEnabled = YES;
     _parallaxMenuMinimumRelativeValue = -15;
@@ -521,7 +522,10 @@
         if (self.scaleBackgroundImageView) {
             self.backgroundImageView.transform = CGAffineTransformMakeScale(backgroundViewScale, backgroundViewScale);
         }
-        self.menuViewContainer.transform = CGAffineTransformMakeScale(menuViewScale, menuViewScale);
+        
+        if(self.scaleMenuView) {
+            self.menuViewContainer.transform = CGAffineTransformMakeScale(menuViewScale, menuViewScale);
+        }
         
         if (self.scaleBackgroundImageView) {
             if (backgroundViewScale < 1) {


### PR DESCRIPTION
While using the `menuViewControllerTransformation` property, I found it didn't stop the menuViewController animation (scaling), while panning (`panGestureEnabled` is enabled).

My aim was to disable the menu scaling effect (yeah, so boring, I know :beer:), so I thought about this simple property to completely remove the scaling animation (defaulting it to YES, so no changes are made for whoever is yet using RESideMenu).

This pull request is just a proposal/discussion. I'd like to find a better way to handle the custom transformation even while panning.
However for now this PR gives a one-liner to solve the problems for this particular scenario (commonly used in combination with `menuViewControllerTransformation = CGAffineTransformIdentity`)

Tested with leftMenuViewController.
