### PR TITLE
Switch to simple mode without fancy animation

### DIFF
--- a/RESideMenu/RESideMenu.h
+++ b/RESideMenu/RESideMenu.h
@@ -45,6 +45,8 @@
 @property (strong, readwrite, nonatomic) UIViewController *rightMenuViewController;
 @property (weak, readwrite, nonatomic) id<RESideMenuDelegate> delegate;
 
+@property (assign, readwrite, nonatomic) BOOL simpleMode;
+
 @property (assign, readwrite, nonatomic) NSTimeInterval animationDuration;
 @property (strong, readwrite, nonatomic) UIImage *backgroundImage;
 @property (assign, readwrite, nonatomic) BOOL panGestureEnabled;

--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -118,6 +118,41 @@
 }
 
 #pragma mark -
+#pragma mark Getters (Simple mode)
+
+- (BOOL)scaleContentView
+{
+    if (self.simpleMode) {
+        return NO;
+    }
+    return _scaleContentView;
+}
+
+- (BOOL)scaleMenuView
+{
+    if (self.simpleMode) {
+        return NO;
+    }
+    return _scaleMenuView;
+}
+
+- (BOOL)scaleBackgroundImageView
+{
+    if (self.simpleMode) {
+        return NO;
+    }
+    return _scaleBackgroundImageView;
+}
+
+- (BOOL)parallaxEnabled
+{
+    if (self.simpleMode) {
+        return NO;
+    }
+    return _parallaxEnabled;
+}
+
+#pragma mark -
 #pragma mark Public methods
 
 - (id)initWithContentViewController:(UIViewController *)contentViewController leftMenuViewController:(UIViewController *)leftMenuViewController rightMenuViewController:(UIViewController *)rightMenuViewController
@@ -578,9 +613,14 @@
     }
     
     if (recognizer.state == UIGestureRecognizerStateChanged) {
+        CGFloat contentOffset = UIInterfaceOrientationIsLandscape([[UIApplication sharedApplication] statusBarOrientation]) ? self.contentViewInLandscapeOffsetCenterX : self.contentViewInPortraitOffsetCenterX;
+        CGFloat maxPanWidth = self.contentViewContainer.bounds.size.width/2 + contentOffset;
+        
         CGFloat delta = 0;
         if (self.visible) {
             delta = self.originalPoint.x != 0 ? (point.x + self.originalPoint.x) / self.originalPoint.x : 0;
+        } else if (self.simpleMode) {
+            delta = point.x / maxPanWidth;
         } else {
             delta = point.x / self.view.frame.size.width;
         }
@@ -628,6 +668,27 @@
             point.x = MAX(point.x, -[UIScreen mainScreen].bounds.size.height);
         } else {
             point.x = MIN(point.x, [UIScreen mainScreen].bounds.size.height);
+        }
+        if (self.simpleMode) {
+            if (self.leftMenuVisible && self.rightMenuVisible) {
+                NSAssert(FALSE, @"WARNING: both left and right menu visible");
+            } else if (self.leftMenuVisible) {
+                if (point.x > 0) {
+                    point.x = 0;
+                } else if (point.x < -maxPanWidth) {
+                    point.x = -maxPanWidth;
+                }
+            } else if (self.rightMenuVisible) {
+                if (point.x < 0) {
+                    point.x = 0;
+                } else if (point.x > maxPanWidth) {
+                    point.x = maxPanWidth;
+                }
+            } else if (point.x < -maxPanWidth){
+                point.x = -maxPanWidth;
+            } else if (point.x > maxPanWidth) {
+                point.x = maxPanWidth;
+            }
         }
         [recognizer setTranslation:point inView:self.view];
         

--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -324,7 +324,7 @@
             self.contentViewContainer.transform = CGAffineTransformIdentity;
         }
         
-        if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_7_1) {
+        if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_7_0) {
             self.contentViewContainer.center = CGPointMake((UIInterfaceOrientationIsLandscape([[UIApplication sharedApplication] statusBarOrientation]) ? self.contentViewInLandscapeOffsetCenterX + CGRectGetWidth(self.view.frame) : self.contentViewInPortraitOffsetCenterX + CGRectGetWidth(self.view.frame)), self.contentViewContainer.center.y);
         } else {
             self.contentViewContainer.center = CGPointMake((UIInterfaceOrientationIsLandscape([[UIApplication sharedApplication] statusBarOrientation]) ? self.contentViewInLandscapeOffsetCenterX + CGRectGetHeight(self.view.frame) : self.contentViewInPortraitOffsetCenterX + CGRectGetWidth(self.view.frame)), self.contentViewContainer.center.y);


### PR DESCRIPTION
I needed just simple side menu without that fancy animations, so for convenient added simpleMode property for turning simple mode on.

Other reason why I do so was that without fancy animation I wasn't able to force pan to stop at content offset value and not pan more. This functionality wasn't present.

Besides side menu dim wasn't working right. When i was swiping from side, dim from 1 to 0 was changing in respect to view width and not in respect to content offset value (old code 533 line).
