### PR TITLE
Fix bug

### DIFF
--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -133,6 +133,11 @@
 
 - (void)setContentViewController:(UIViewController *)contentViewController animated:(BOOL)animated
 {
+    if (_contentViewController == contentViewController)
+    {
+        return;
+    }
+    
     if (!animated) {
         [self setContentViewController:contentViewController];
     } else {


### PR DESCRIPTION
In the method setContentViewController:animated:, if the
contentViewController == _contentViewController, then
[self.contentViewContainer addSubview:contentViewController.view]; will
cause a crash
