### PR TITLE
IBInspectable and StoryboardID loading

### DIFF
--- a/RESideMenu/RESideMenu.h
+++ b/RESideMenu/RESideMenu.h
@@ -34,6 +34,12 @@
 
 @interface RESideMenu : UIViewController <UIGestureRecognizerDelegate>
 
+#if __IPHONE_8_0
+@property (strong, readwrite, nonatomic) IBInspectable NSString *contentViewStoryboardID;
+@property (strong, readwrite, nonatomic) IBInspectable NSString *leftMenuViewStoryboardID;
+@property (strong, readwrite, nonatomic) IBInspectable NSString *rightMenuViewStoryboardID;
+#endif
+
 @property (strong, readwrite, nonatomic) UIViewController *contentViewController;
 @property (strong, readwrite, nonatomic) UIViewController *leftMenuViewController;
 @property (strong, readwrite, nonatomic) UIViewController *rightMenuViewController;

--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -100,6 +100,24 @@
     _contentViewScaleValue = 0.7f;
 }
 
+#if __IPHONE_8_0
+- (void)awakeFromNib
+{
+    if (self.contentViewStoryboardID != nil)
+    {
+        self.contentViewController = [self.storyboard instantiateViewControllerWithIdentifier:self.contentViewStoryboardID];
+    }
+    if (self.leftMenuViewStoryboardID != nil)
+    {
+        self.leftMenuViewController = [self.storyboard instantiateViewControllerWithIdentifier:self.leftMenuViewStoryboardID];
+    }
+    if (self.rightMenuViewStoryboardID != nil)
+    {
+        self.rightMenuViewController = [self.storyboard instantiateViewControllerWithIdentifier:self.rightMenuViewStoryboardID];
+    }
+}
+#endif
+
 #pragma mark -
 #pragma mark Public methods
 


### PR DESCRIPTION
All fields Xcode 6 currently support as IBInspectable are marks to be. However the names of some are longer than the editor can display and get truncated.

Three additional fields that allow loading Content and Left and Right Menu Views from Storyboard without the need to subclass RESideMenu
