### PR TITLE
Update panFromEdge to an enum type REPanDirection to allow more directions

### DIFF
--- a/RESideMenu/RESideMenu.h
+++ b/RESideMenu/RESideMenu.h
@@ -30,6 +30,11 @@
 #define IBInspectable
 #endif
 
+typedef enum {
+    REPanDirectionFromEdge = 0,
+    REPanDirectionFromEverywhere = 1,
+} REPanDirection;
+
 @protocol RESideMenuDelegate;
 
 @interface RESideMenu : UIViewController <UIGestureRecognizerDelegate>
@@ -48,7 +53,7 @@
 @property (assign, readwrite, nonatomic) NSTimeInterval animationDuration;
 @property (strong, readwrite, nonatomic) UIImage *backgroundImage;
 @property (assign, readwrite, nonatomic) BOOL panGestureEnabled;
-@property (assign, readwrite, nonatomic) BOOL panFromEdge;
+@property (assign, readwrite, nonatomic) REPanDirection panDirection;
 @property (assign, readwrite, nonatomic) NSUInteger panMinimumOpenThreshold;
 @property (assign, readwrite, nonatomic) IBInspectable BOOL interactivePopGestureRecognizerEnabled;
 @property (assign, readwrite, nonatomic) IBInspectable BOOL fadeMenuView;

--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -103,7 +103,7 @@
     _bouncesHorizontally = YES;
     
     _panGestureEnabled = YES;
-    _panFromEdge = YES;
+    _panDirection = REPanDirectionFromEdge;
     _panMinimumOpenThreshold = 60.0;
     
     _contentViewShadowEnabled = NO;
@@ -528,12 +528,16 @@
        }
     );
   
-    if (self.panFromEdge && [gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]] && !self.visible) {
-        CGPoint point = [touch locationInView:gestureRecognizer.view];
-        if (point.x < 20.0 || point.x > self.view.frame.size.width - 20.0) {
+    if ([gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]] && !self.visible) {
+        if (self.panDirection == REPanDirectionFromEdge) {
+            CGPoint point = [touch locationInView:gestureRecognizer.view];
+            if (point.x < 20.0 || point.x > self.view.frame.size.width - 20.0) {
+                return YES;
+            } else {
+                return NO;
+            }
+        } else if (self.panDirection == REPanDirectionFromEveryWhere){
             return YES;
-        } else {
-            return NO;
         }
     }
     


### PR DESCRIPTION
Update the panFromEdge to an enum type, which can allow REPanDirectionFromEdge & REPanDirectionFromEverywhere. By REPanDirectionFromEverywhere, we can pan the side menus from the centre part of the content view.
