### PR TITLE
add UIKit import to fix build error

### DIFF
--- a/RESideMenu/RECommonFunctions.m
+++ b/RESideMenu/RECommonFunctions.m
@@ -24,6 +24,7 @@
 //
 
 #import "RECommonFunctions.h"
+#import <UIKit/UIKit.h>
 
 BOOL RESideMenuUIKitIsFlatMode(void)
 {


### PR DESCRIPTION
When adding the classes to a swift project directly, RESideMenu will fail to build because of the lack of import statement for UIKit.