### PR TITLE
Use appearance transition methods on menu view controllers so that view events are sent

### DIFF
--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -274,6 +274,7 @@
     if (!self.leftMenuViewController) {
         return;
     }
+    [self.leftMenuViewController beginAppearanceTransition:YES animated:YES];
     self.leftMenuViewController.view.hidden = NO;
     self.rightMenuViewController.view.hidden = YES;
     [self.view.window endEditing:YES];
@@ -302,6 +303,7 @@
             
     } completion:^(BOOL finished) {
         [self addContentViewControllerMotionEffects];
+        [self.leftMenuViewController endAppearanceTransition];
         
         if (!self.visible && [self.delegate conformsToProtocol:@protocol(RESideMenuDelegate)] && [self.delegate respondsToSelector:@selector(sideMenu:didShowMenuViewController:)]) {
             [self.delegate sideMenu:self didShowMenuViewController:self.leftMenuViewController];
@@ -319,6 +321,7 @@
     if (!self.rightMenuViewController) {
         return;
     }
+    [self.rightMenuViewController beginAppearanceTransition:YES animated:YES];
     self.leftMenuViewController.view.hidden = YES;
     self.rightMenuViewController.view.hidden = NO;
     [self.view.window endEditing:YES];
@@ -342,6 +345,7 @@
             self.backgroundImageView.transform = CGAffineTransformIdentity;
         
     } completion:^(BOOL finished) {
+        [self.rightMenuViewController endAppearanceTransition];
         if (!self.rightMenuVisible && [self.delegate conformsToProtocol:@protocol(RESideMenuDelegate)] && [self.delegate respondsToSelector:@selector(sideMenu:didShowMenuViewController:)]) {
             [self.delegate sideMenu:self didShowMenuViewController:self.rightMenuViewController];
         }
@@ -365,6 +369,8 @@
 - (void)hideMenuViewControllerAnimated:(BOOL)animated
 {
     BOOL rightMenuVisible = self.rightMenuVisible;
+    UIViewController *visibleMenuViewController = rightMenuVisible ? self.rightMenuViewController : self.leftMenuViewController;
+    [visibleMenuViewController beginAppearanceTransition:NO animated:animated];
     if ([self.delegate conformsToProtocol:@protocol(RESideMenuDelegate)] && [self.delegate respondsToSelector:@selector(sideMenu:willHideMenuViewController:)]) {
         [self.delegate sideMenu:self willHideMenuViewController:rightMenuVisible ? self.rightMenuViewController : self.leftMenuViewController];
     }
@@ -404,6 +410,7 @@
         if (!strongSelf) {
             return;
         }
+        [visibleMenuViewController endAppearanceTransition];
         if (!strongSelf.visible && [strongSelf.delegate conformsToProtocol:@protocol(RESideMenuDelegate)] && [strongSelf.delegate respondsToSelector:@selector(sideMenu:didHideMenuViewController:)]) {
             [strongSelf.delegate sideMenu:strongSelf didHideMenuViewController:rightMenuVisible ? strongSelf.rightMenuViewController : strongSelf.leftMenuViewController];
         }


### PR DESCRIPTION
This is an attempt at a fix for #174. Using `beginAppearanceTransition:animated:` and `endAppearanceTransition` ensure that the menu view controller's `viewWillAppear:`, `viewDidAppear:`, `viewWillDisappear:`, and `viewDidDisappear:` are messaged.

From [the documentation](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIViewController_Class/index.html#//apple_ref/occ/instm/UIViewController/beginAppearanceTransition:animated:) regarding appearance transition methods:
> __Discussion__

> If you are implementing a custom container controller, use this method to tell the child that its views are about to appear or disappear. Do not invoke `viewWillAppear:`, `viewWillDisappear:`, `viewDidAppear:`, or `viewDidDisappear:` directly.


I'm not super familiar with RESideMenu, so there may be a better place for some of these calls. In my testing, the proper view events are always sent when a menu view controller is coming into/going out of view, but there are times when the menu view controller may not be on screen that a view event is still fired (e.g. if `hideMenuViewControllerAnimated:` is messaged when neither menu view controller is visible, which is currently allowed by RESideMenu).

This does not add any appearance transition calls for the content view controller, where the view never fully leaves the screen (and thus, arguably, does not "disappear").