### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,32 +132,32 @@ Switch content view controllers:
 You can customize the following properties of `RESideMenu`:
 
 ``` objective-c
-@property (assign, readwrite, nonatomic) NSTimeInterval animationDuration;
-@property (strong, readwrite, nonatomic) UIImage *backgroundImage;
-@property (assign, readwrite, nonatomic) BOOL panGestureEnabled;
-@property (assign, readwrite, nonatomic) BOOL panFromEdge;
-@property (assign, readwrite, nonatomic) NSUInteger panMinimumOpenThreshold;
-@property (assign, readwrite, nonatomic) BOOL interactivePopGestureRecognizerEnabled;
-@property (assign, readwrite, nonatomic) BOOL scaleContentView;
-@property (assign, readwrite, nonatomic) BOOL scaleBackgroundImageView;
-@property (assign, readwrite, nonatomic) BOOL scaleMenuView;
-@property (assign, readwrite, nonatomic) BOOL contentViewShadowEnabled;
-@property (assign, readwrite, nonatomic) UIColor *contentViewShadowColor;
-@property (assign, readwrite, nonatomic) CGSize contentViewShadowOffset;
-@property (assign, readwrite, nonatomic) CGFloat contentViewShadowOpacity;
-@property (assign, readwrite, nonatomic) CGFloat contentViewShadowRadius;
-@property (assign, readwrite, nonatomic) CGFloat contentViewScaleValue;
-@property (assign, readwrite, nonatomic) CGFloat contentViewInLandscapeOffsetCenterX;
-@property (assign, readwrite, nonatomic) CGFloat contentViewInPortraitOffsetCenterX;
-@property (assign, readwrite, nonatomic) CGFloat parallaxMenuMinimumRelativeValue;
-@property (assign, readwrite, nonatomic) CGFloat parallaxMenuMaximumRelativeValue;
-@property (assign, readwrite, nonatomic) CGFloat parallaxContentMinimumRelativeValue;
-@property (assign, readwrite, nonatomic) CGFloat parallaxContentMaximumRelativeValue;
-@property (assign, readwrite, nonatomic) CGAffineTransform menuViewControllerTransformation;
-@property (assign, readwrite, nonatomic) BOOL parallaxEnabled;
-@property (assign, readwrite, nonatomic) BOOL bouncesHorizontally;
-@property (assign, readwrite, nonatomic) UIStatusBarStyle menuPreferredStatusBarStyle;
-@property (assign, readwrite, nonatomic) BOOL menuPrefersStatusBarHidden;
+NSTimeInterval animationDuration;
+UIImage *backgroundImage;
+BOOL panGestureEnabled;
+BOOL panFromEdge;
+NSUInteger panMinimumOpenThreshold;
+BOOL interactivePopGestureRecognizerEnabled;
+BOOL scaleContentView;
+BOOL scaleBackgroundImageView;
+BOOL scaleMenuView;
+BOOL contentViewShadowEnabled;
+UIColor *contentViewShadowColor;
+CGSize contentViewShadowOffset;
+CGFloat contentViewShadowOpacity;
+CGFloat contentViewShadowRadius;
+CGFloat contentViewScaleValue;
+CGFloat contentViewInLandscapeOffsetCenterX;
+CGFloat contentViewInPortraitOffsetCenterX;
+CGFloat parallaxMenuMinimumRelativeValue;
+CGFloat parallaxMenuMaximumRelativeValue;
+CGFloat parallaxContentMinimumRelativeValue;
+CGFloat parallaxContentMaximumRelativeValue;
+CGAffineTransform menuViewControllerTransformation;
+BOOL parallaxEnabled;
+BOOL bouncesHorizontally;
+UIStatusBarStyle menuPreferredStatusBarStyle;
+BOOL menuPrefersStatusBarHidden;
 ```
 
 If you set a backgroundImage, don't forget to set the Menu View Controller's background color to clear color.


### PR DESCRIPTION
Removed unnecessary implementation details from the customization properties.

It would hugely help if the default values for these properties would be presented, but I don't have time now to look for them. Something like this:

| Type | Property | Default value |
| --- | --- | --- |
| `NSTimeInterval` | animationDuration | **1** |
