### PR TITLE
Add content view controller changed delegate

### DIFF
--- a/Examples/Simple/RESideMenuExample/DEMOAppDelegate.m
+++ b/Examples/Simple/RESideMenuExample/DEMOAppDelegate.m
@@ -62,4 +62,12 @@
     NSLog(@"didHideMenuViewController: %@", NSStringFromClass([menuViewController class]));
 }
 
+-(void)sideMenu:(RESideMenu *)sideMenu willHideMenuViewController:(UIViewController *)menuViewController contentViewControllerChanged:(BOOL)contentViewControllerChanged {
+    NSLog(@"willHideMenuViewController: %@ - changed: %@", NSStringFromClass([menuViewController class]), contentViewControllerChanged ? @"YES" : @"NO");
+}
+
+-(void)sideMenu:(RESideMenu *)sideMenu didHideMenuViewController:(UIViewController *)menuViewController contentViewControllerChanged:(BOOL)contentViewControllerChanged {
+    NSLog(@"didHideMenuViewController: %@ - changed: %@", NSStringFromClass([menuViewController class]), contentViewControllerChanged ? @"YES" : @"NO");
+}
+
 @end

--- a/RESideMenu/RESideMenu.h
+++ b/RESideMenu/RESideMenu.h
@@ -94,4 +94,6 @@
 - (void)sideMenu:(RESideMenu *)sideMenu willHideMenuViewController:(UIViewController *)menuViewController;
 - (void)sideMenu:(RESideMenu *)sideMenu didHideMenuViewController:(UIViewController *)menuViewController;
 
+- (void)sideMenu:(RESideMenu *)sideMenu willHideMenuViewController:(UIViewController *)menuViewController contentViewControllerChanged:(BOOL)contentViewControllerChanged;
+- (void)sideMenu:(RESideMenu *)sideMenu didHideMenuViewController:(UIViewController *)menuViewController contentViewControllerChanged:(BOOL)contentViewControllerChanged;
 @end

--- a/RESideMenu/RESideMenu.h
+++ b/RESideMenu/RESideMenu.h
@@ -73,6 +73,7 @@
 @property (assign, readwrite, nonatomic) IBInspectable BOOL bouncesHorizontally;
 @property (assign, readwrite, nonatomic) UIStatusBarStyle menuPreferredStatusBarStyle;
 @property (assign, readwrite, nonatomic) IBInspectable BOOL menuPrefersStatusBarHidden;
+@property (assign, readwrite, nonatomic) BOOL contentViewControllerChanged;
 
 - (id)initWithContentViewController:(UIViewController *)contentViewController
              leftMenuViewController:(UIViewController *)leftMenuViewController

--- a/RESideMenu/RESideMenu.h
+++ b/RESideMenu/RESideMenu.h
@@ -80,6 +80,7 @@
 - (void)presentLeftMenuViewController;
 - (void)presentRightMenuViewController;
 - (void)hideMenuViewController;
+- (void)hideMenuViewControllerAnimated:(BOOL)animated;
 - (void)setContentViewController:(UIViewController *)contentViewController animated:(BOOL)animated;
 
 @end

--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -38,7 +38,6 @@
 @property (strong, readwrite, nonatomic) UIView *menuViewContainer;
 @property (strong, readwrite, nonatomic) UIView *contentViewContainer;
 @property (assign, readwrite, nonatomic) BOOL didNotifyDelegate;
-@property (assign, readwrite, nonatomic) BOOL contentViewControllerChanged;
 
 @end
 


### PR DESCRIPTION
Add a `optional` delegate for getting information if the `contentViewController` is changed will hiding the menu view controller.

We need this information, because if a user closes the menu with a pan gesture or clicking the same menu point as he was we do other stuff as the contentViewController is not changed.
