### PR TITLE
Update of the status bar on the hide menu is now called at the completion

### DIFF
--- a/RESideMenu.podspec
+++ b/RESideMenu.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = 'RESideMenu'
-  s.version     = '4.0.7'
+  s.version     = '4.0.8'
   s.authors     = { 'Roman Efimov' => 'romefimov@gmail.com' }
   s.homepage    = 'https://github.com/romaonthego/RESideMenu'
   s.summary     = 'iOS 7 style side menu with parallax effect.'

--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -411,6 +411,7 @@
             return;
         }
         [visibleMenuViewController endAppearanceTransition];
+        [self statusBarNeedsAppearanceUpdate];
         if (!strongSelf.visible && [strongSelf.delegate conformsToProtocol:@protocol(RESideMenuDelegate)] && [strongSelf.delegate respondsToSelector:@selector(sideMenu:didHideMenuViewController:)]) {
             [strongSelf.delegate sideMenu:strongSelf didHideMenuViewController:rightMenuVisible ? strongSelf.rightMenuViewController : strongSelf.leftMenuViewController];
         }
@@ -428,7 +429,6 @@
         animationBlock();
         completionBlock();
     }
-    [self statusBarNeedsAppearanceUpdate];
 }
 
 - (void)addContentButton


### PR DESCRIPTION
This fix the bad update when switching form two `contentViewController` with different status bar colors.

When called alongside with a `hideMenuViewController` the `statusBarNeedsAppearanceUpdate` called outside the completion block of the `hideMenuViewControllerAnimated` caused the status bar to switch back to the previous contentViewController, since this is triggered before the completionBlock of the animation in `setContentViewController`.

Before fix : 
![jun 08 2015 11 34](https://cloud.githubusercontent.com/assets/1458311/8032967/6cd48cde-0dd2-11e5-85f3-c8ac21ada560.gif)
After fix : 
![jun 08 2015 11 36](https://cloud.githubusercontent.com/assets/1458311/8032984/a6738b34-0dd2-11e5-9650-36f92d050b84.gif)
