### PR TITLE
call awakeFromNib super implementation

### DIFF
--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -67,6 +67,7 @@
 #if __IPHONE_8_0
 - (void)awakeFromNib
 {
+    [super awakeFromNib];
     if (self.contentViewStoryboardID) {
         self.contentViewController = [self.storyboard instantiateViewControllerWithIdentifier:self.contentViewStoryboardID];
     }


### PR DESCRIPTION
hi, I am sorry to bother you with such a small commit. Recently I write a class to implement custom relationship segue, [SMBCustomRelationshipSegue](https://github.com/SuperMarioBean/SMBCustomRelationshipSegue), and I use your awesome reside menu as a example to show how to connect custom relationship just in storyboard, everything works fine until I want improve my implementation to use awakeFromNib method instead of viewDidLoad Method. I found: 

```
#if __IPHONE_8_0
- (void)awakeFromNib
{
    if (self.contentViewStoryboardID) {
        self.contentViewController = [self.storyboard instantiateViewControllerWithIdentifier:self.contentViewStoryboardID];
    }
    if (self.leftMenuViewStoryboardID) {
        self.leftMenuViewController = [self.storyboard instantiateViewControllerWithIdentifier:self.leftMenuViewStoryboardID];
    }
    if (self.rightMenuViewStoryboardID) {
    self.rightMenuViewController = [self.storyboard instantiateViewControllerWithIdentifier:self.rightMenuViewStoryboardID];
    }
}
#endif
```

because your implementation did not call awakeFromNib's super's implementation, my lib could not to hook the method to work well. so I created this pull request to figure out why not call the super implementaion as [usual](http://stackoverflow.com/questions/3989665/should-i-call-super-awakefromnib). My lib works well with your lib under iOS 7.X. 
