### PR TITLE
Disable readable content guide to keep same cell margins as before.

### DIFF
--- a/Examples/Storyboards/RESideMenuStoryboardsExample/DEMOLeftMenuViewController.m
+++ b/Examples/Storyboards/RESideMenuStoryboardsExample/DEMOLeftMenuViewController.m
@@ -33,7 +33,11 @@
         tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
         tableView.bounces = NO;
         tableView.scrollsToTop = NO;
+        if ([tableView respondsToSelector:@selector(setCellLayoutMarginsFollowReadableWidth:)]) {
+            tableView.cellLayoutMarginsFollowReadableWidth = NO;
+        }
         tableView;
+        
     });
     [self.view addSubview:self.tableView];
 }

--- a/Examples/Storyboards/RESideMenuStoryboardsExample/DEMORightMenuViewController.m
+++ b/Examples/Storyboards/RESideMenuStoryboardsExample/DEMORightMenuViewController.m
@@ -32,6 +32,9 @@
         tableView.backgroundView = nil;
         tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
         tableView.bounces = NO;
+        if ([tableView respondsToSelector:@selector(setCellLayoutMarginsFollowReadableWidth:)]) {
+            tableView.cellLayoutMarginsFollowReadableWidth = NO;
+        }
         tableView;
     });
     [self.view addSubview:self.tableView];


### PR DESCRIPTION
In iOS 9 the new feature called readable content guide makes the cell margins much wider on iPad.
