### PR TITLE
added option to enable / disable left- and right pan gestures

### DIFF
--- a/RESideMenu/RESideMenu.h
+++ b/RESideMenu/RESideMenu.h
@@ -48,6 +48,8 @@
 @property (assign, readwrite, nonatomic) NSTimeInterval animationDuration;
 @property (strong, readwrite, nonatomic) UIImage *backgroundImage;
 @property (assign, readwrite, nonatomic) BOOL panGestureEnabled;
+@property (assign, readwrite, nonatomic) IBInspectable BOOL panGestureLeftEnabled;
+@property (assign, readwrite, nonatomic) IBInspectable BOOL panGestureRightEnabled;
 @property (assign, readwrite, nonatomic) BOOL panFromEdge;
 @property (assign, readwrite, nonatomic) NSUInteger panMinimumOpenThreshold;
 @property (assign, readwrite, nonatomic) IBInspectable BOOL interactivePopGestureRecognizerEnabled;

--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -103,6 +103,8 @@
     _bouncesHorizontally = YES;
     
     _panGestureEnabled = YES;
+    _panGestureLeftEnabled = YES;
+    _panGestureRightEnabled = YES;
     _panFromEdge = YES;
     _panMinimumOpenThreshold = 60.0;
     
@@ -537,11 +539,13 @@
   
     if (self.panFromEdge && [gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]] && !self.visible) {
         CGPoint point = [touch locationInView:gestureRecognizer.view];
-        if (point.x < 20.0 || point.x > self.view.frame.size.width - 20.0) {
+        if(self.panGestureLeftEnabled && point.x < 20.0) {
             return YES;
-        } else {
-            return NO;
+        } else if(self.panGestureRightEnabled && point.x > self.view.frame.size.width - 20.0) {
+            return YES;
         }
+      
+        return NO;
     }
     
     return YES;


### PR DESCRIPTION
In some cases you will want to disable let the pan gesture recognizer to fail if you do not have a left / or right menu assigned. For example, if your contentViewController is a PageViewController and you want to prioritise the pan gesture of the RESideMenu over the pan gesture of the PageView, using _requireGestureRecognizerToFail_, you will want the gesture to fail if you do not have a right-menu assigned.
