### PR TITLE
ignore interactive pop gesture recognizer for right menu

### DIFF
--- a/RESideMenu/RESideMenu.h
+++ b/RESideMenu/RESideMenu.h
@@ -51,6 +51,7 @@
 @property (assign, readwrite, nonatomic) BOOL panFromEdge;
 @property (assign, readwrite, nonatomic) NSUInteger panMinimumOpenThreshold;
 @property (assign, readwrite, nonatomic) IBInspectable BOOL interactivePopGestureRecognizerEnabled;
+@property (assign, readwrite, nonatomic) IBInspectable BOOL interactivePopGestureRecognizerIgnoreRightMenu;
 @property (assign, readwrite, nonatomic) IBInspectable BOOL fadeMenuView;
 @property (assign, readwrite, nonatomic) IBInspectable BOOL scaleContentView;
 @property (assign, readwrite, nonatomic) IBInspectable BOOL scaleBackgroundImageView;

--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -526,18 +526,23 @@
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
 {
+    const CGFloat edgeWidth = 20;
+    const CGPoint point = [touch locationInView:gestureRecognizer.view];
+    const BOOL isLeftEdge = point.x < edgeWidth;
+    const BOOL isRightEdge = point.x > self.view.frame.size.width - edgeWidth;
+    
     IF_IOS7_OR_GREATER(
        if (self.interactivePopGestureRecognizerEnabled && [self.contentViewController isKindOfClass:[UINavigationController class]]) {
            UINavigationController *navigationController = (UINavigationController *)self.contentViewController;
-           if (navigationController.viewControllers.count > 1 && navigationController.interactivePopGestureRecognizer.enabled) {
+           const BOOL shouldIgnore = self.interactivePopGestureRecognizerIgnoreRightMenu && (!self.rightMenuViewController.view.hidden || isRightEdge);
+           if (!shouldIgnore && navigationController.viewControllers.count > 1 && navigationController.interactivePopGestureRecognizer.enabled) {
                return NO;
            }
        }
     );
   
     if (self.panFromEdge && [gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]] && !self.visible) {
-        CGPoint point = [touch locationInView:gestureRecognizer.view];
-        if (point.x < 20.0 || point.x > self.view.frame.size.width - 20.0) {
+        if (isLeftEdge || isRightEdge) {
             return YES;
         } else {
             return NO;

--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -86,6 +86,7 @@
     
     _animationDuration = 0.35f;
     _interactivePopGestureRecognizerEnabled = YES;
+    _interactivePopGestureRecognizerIgnoreRightMenu = NO;
   
     _menuViewControllerTransformation = CGAffineTransformMakeScale(1.5f, 1.5f);
     


### PR DESCRIPTION
As interactive pop gesture only affects left menu, in our project, we would like to ignore it for the right menu and we think it might be a requirement for some other projects:

Senario:
It's a restaurant menu app, left menu is for navigating of menu/history orders/about us, which will only be able to open when we are in 1 level. Right menu is the order/shopping cart, which can be accessed regardless how many level of content view
