### PR TITLE
PanGesture recognizable zone width 

### DIFF
--- a/RESideMenu/RESideMenu.h
+++ b/RESideMenu/RESideMenu.h
@@ -50,6 +50,7 @@
 @property (assign, readwrite, nonatomic) BOOL panGestureEnabled;
 @property (assign, readwrite, nonatomic) BOOL panFromEdge;
 @property (assign, readwrite, nonatomic) NSUInteger panMinimumOpenThreshold;
+@property (assign, readwrite, nonatomic) IBInspectable CGFloat panFromEdgeZoneWidth;
 @property (assign, readwrite, nonatomic) IBInspectable BOOL interactivePopGestureRecognizerEnabled;
 @property (assign, readwrite, nonatomic) IBInspectable BOOL fadeMenuView;
 @property (assign, readwrite, nonatomic) IBInspectable BOOL scaleContentView;

--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -104,6 +104,7 @@
     
     _panGestureEnabled = YES;
     _panFromEdge = YES;
+    _panFromEdgeZoneWidth = 20.0f;
     _panMinimumOpenThreshold = 60.0;
     
     _contentViewShadowEnabled = NO;
@@ -537,7 +538,7 @@
   
     if (self.panFromEdge && [gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]] && !self.visible) {
         CGPoint point = [touch locationInView:gestureRecognizer.view];
-        if (point.x < 20.0 || point.x > self.view.frame.size.width - 20.0) {
+        if (point.x < self.panFromEdgeZoneWidth || point.x > self.view.frame.size.width - self.panFromEdgeZoneWidth) {
             return YES;
         } else {
             return NO;


### PR DESCRIPTION
Added new IBInspectable property - panFromEdgeZoneWidth. It contains the width of zone, where user's pan gesture should be recognized.