### PR TITLE
Add new customization flag: preventOvershoot

### DIFF
--- a/RESideMenu/RESideMenu.h
+++ b/RESideMenu/RESideMenu.h
@@ -71,6 +71,7 @@
 @property (assign, readwrite, nonatomic) CGAffineTransform menuViewControllerTransformation;
 @property (assign, readwrite, nonatomic) IBInspectable BOOL parallaxEnabled;
 @property (assign, readwrite, nonatomic) IBInspectable BOOL bouncesHorizontally;
+@property (assign, readwrite, nonatomic) IBInspectable BOOL preventOvershoot;
 @property (assign, readwrite, nonatomic) UIStatusBarStyle menuPreferredStatusBarStyle;
 @property (assign, readwrite, nonatomic) IBInspectable BOOL menuPrefersStatusBarHidden;
 

--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -101,6 +101,7 @@
     _parallaxContentMaximumRelativeValue = 25;
     
     _bouncesHorizontally = YES;
+    _preventOvershoot = NO;
     
     _panGestureEnabled = YES;
     _panFromEdge = YES;
@@ -629,6 +630,25 @@
         } else {
             point.x = MIN(point.x, [UIScreen mainScreen].bounds.size.height);
         }
+        
+        // Prevent main content going past offsetCenterX
+        //
+        if (self.preventOvershoot && !self.bouncesHorizontally) {
+            if (UIDeviceOrientationIsLandscape([UIDevice currentDevice].orientation)) {
+                if (point.x < 0) {
+                    point.x = MAX(point.x, -([UIScreen mainScreen].bounds.size.width / 2 + self.contentViewInLandscapeOffsetCenterX + self.originalPoint.x));
+                } else {
+                    point.x = MIN(point.x, [UIScreen mainScreen].bounds.size.width / 2 + self.contentViewInLandscapeOffsetCenterX - self.originalPoint.x);
+                }
+            } else {
+                if (point.x < 0) {
+                    point.x = MAX(point.x, -([UIScreen mainScreen].bounds.size.width / 2 + self.contentViewInPortraitOffsetCenterX + self.originalPoint.x));
+                } else {
+                    point.x = MIN(point.x, [UIScreen mainScreen].bounds.size.width / 2 + self.contentViewInPortraitOffsetCenterX - self.originalPoint.x);
+                }
+            }
+        }
+        
         [recognizer setTranslation:point inView:self.view];
         
         if (!self.didNotifyDelegate) {


### PR DESCRIPTION
Prevent the top content view to go past the offsetCenterX if bouncesHorizontally is disabled.

This is important when the left/right views are of fixed size and there's no content past offsetCenter.
