### PR TITLE
Return contentViewController's supportedInterfaceOrientations

### DIFF
--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -782,6 +782,11 @@
     return self.contentViewController.shouldAutorotate;
 }
 
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations
+{
+    return self.contentViewController.supportedInterfaceOrientations;
+}
+
 - (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
 {
     if (self.visible) {


### PR DESCRIPTION
Override `-supportedInterfaceOrientations` and passthrough `contentViewController`'s `supportedInterfaceOrientations` to allow it to control which orientations `RESideMenu` can rotate to.
