### PR TITLE
fixed pan gesture conflict problem

### DIFF
--- a/RESideMenu/RESideMenu.m
+++ b/RESideMenu/RESideMenu.m
@@ -38,7 +38,7 @@
 @property (strong, readwrite, nonatomic) UIView *menuViewContainer;
 @property (strong, readwrite, nonatomic) UIView *contentViewContainer;
 @property (assign, readwrite, nonatomic) BOOL didNotifyDelegate;
-
+@property (strong, readwrite, nonatomic) UIPanGestureRecognizer *panGestureRecognizer;
 @end
 
 @implementation RESideMenu
@@ -241,6 +241,7 @@
         UIPanGestureRecognizer *panGestureRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(panGestureRecognized:)];
         panGestureRecognizer.delegate = self;
         [self.view addGestureRecognizer:panGestureRecognizer];
+        self.panGestureRecognizer = panGestureRecognizer;
     }
     
     [self updateContentViewShadow];
@@ -855,6 +856,12 @@
         }
     );
     return statusBarAnimation;
+}
+
+- (void)setPanGestureEnabled:(BOOL)panGestureEnabled
+{
+    _panGestureEnabled = panGestureEnabled;
+    self.panGestureRecognizer.enabled = panGestureEnabled;
 }
 
 @end


### PR DESCRIPTION
Hi,
    Great appreciation for your awesome SlideSlip Framwork. During use, I noticed a problem as belows:
    If an developer adds an SlideLeft or SlideRight gesture into his/her controller, an gesture collision will occur, even if setting "RESideMenu.panGestureEnable = NO". For example, the SlideLeft Delete gesture collision in the 'Edit' mode of UITableView.
    I gave an solution as belows:
    1) add "panGestureRecognizer" property into RESideMenu.m, and let it point to "pan" gesture of view.
    2) rewrite the "set" method of "panGestureEnabled" to change the "enable" property of "panGestureRecongnizer"
Best Regards.
